### PR TITLE
Adds CRC32 hash

### DIFF
--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -78,6 +78,9 @@ func toSum(input chan Result) string {
 			first = false
 		}
 
+		if hasHash(HashNames.CRC32) {
+			str.WriteString(res.CRC32 + "  " + res.File + "\n")
+		}
 		if hasHash(HashNames.MD4) {
 			str.WriteString(res.MD4 + "  " + res.File + "\n")
 		}
@@ -129,6 +132,9 @@ func toHashOnly(input chan Result) (string, bool) {
 	valid := true
 
 	for res := range input {
+		if hasHash(HashNames.CRC32) {
+			str.WriteString(res.CRC32 + "\n")
+		}
 		if hasHash(HashNames.MD4) {
 			str.WriteString(res.MD4 + "\n")
 		}
@@ -189,6 +195,9 @@ func toText(input chan Result) (string, bool) {
 
 		str.WriteString(fmt.Sprintf("%s (%d bytes)\n", res.File, res.Bytes))
 
+		if hasHash(HashNames.CRC32) {
+			str.WriteString("      CRC32 " + res.CRC32 + "\n")
+		}
 		if hasHash(HashNames.MD4) {
 			str.WriteString("        MD4 " + res.MD4 + "\n")
 		}
@@ -292,6 +301,7 @@ func toHashDeep(input chan Result) string {
 }
 
 func printHashes() {
+	fmt.Println(fmt.Sprintf("      CRC32 (%s)", HashNames.CRC32))
 	fmt.Println(fmt.Sprintf("        MD4 (%s)", HashNames.MD4))
 	fmt.Println(fmt.Sprintf("        MD5 (%s)", HashNames.MD5))
 	fmt.Println(fmt.Sprintf("       SHA1 (%s)", HashNames.SHA1))

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -74,6 +74,7 @@ var NoThreads = runtime.NumCPU()
 
 // String mapping for hash names
 var HashNames = Result{
+	CRC32:      "crc32",
 	MD4:        "md4",
 	MD5:        "md5",
 	SHA1:       "sha1",

--- a/processor/structs.go
+++ b/processor/structs.go
@@ -5,6 +5,7 @@ import "time"
 // Holds the result after processing the hashes for the file
 type Result struct {
 	File       string
+	CRC32      string
 	MD4        string
 	MD5        string
 	SHA1       string


### PR DESCRIPTION
Attempts to add CRC32 (IEEE variant - https://pkg.go.dev/hash/crc32@go1.24.1#NewIEEE) as a hash.

Hopefully helps out with #1 👍 

Let me know if you'd like me to amend anything. I've just followed your structure for now. My formatted wanted to re-arrange your imports within `processor/workers.go` I've overridden it for now.

Oh, haven't updated the README!